### PR TITLE
Use backend API for chatbot

### DIFF
--- a/docs/chat.js
+++ b/docs/chat.js
@@ -37,9 +37,9 @@ async function sendMessage() {
   botDiv.classList.add('loading');
 
   try {
-    const aiResponse = await window.generateAIResponse(message);
+    const aiResponse = await window.generateReply(message);
     botDiv.classList.remove('loading');
-    botDiv.querySelector('.message-text').textContent = aiResponse;
+    await typeWriter(botDiv.querySelector('.message-text'), aiResponse);
     appendTimestamp(botDiv);
   } catch (err) {
     console.error('Error generating response:', err);
@@ -67,4 +67,19 @@ function appendTimestamp(el) {
   span.className = 'timestamp';
   span.textContent = new Date().toLocaleTimeString();
   el.appendChild(span);
+}
+
+function typeWriter(el, text, delay = 20) {
+  return new Promise(resolve => {
+    let i = 0;
+    function type() {
+      if (i < text.length) {
+        el.textContent += text.charAt(i++);
+        setTimeout(type, delay);
+      } else {
+        resolve();
+      }
+    }
+    type();
+  });
 }

--- a/docs/chatbot.js
+++ b/docs/chatbot.js
@@ -1,15 +1,15 @@
-// Endpoint for the backend chat API
 const BACKEND_URL = "http://195.201.124.49:8000/chat";
+let history = [];
 
-// Basic placeholder for chatbot functionality
-async function sendMessage(message) {
-  console.log('Sending message:', message);
-  // Send the user's message to the backend and return the reply
-  const resp = await fetch(BACKEND_URL, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ message })
+async function generateReply(userText) {
+  const response = await fetch(BACKEND_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ message: userText, history }),
   });
-  const data = await resp.json();
+  const data = await response.json();
+  history.push({ user: userText, ai: data.reply });
   return data.reply;
 }
+
+window.generateReply = generateReply;

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>SAWA MED Assistant</title>
   <link rel="stylesheet" href="style.css">
-  <script src="fallback-data.js"></script>
-  <script src="dsm5-data.js"></script>
-  <script src="medications-data.js"></script>
-  <script src="therapy-speech.js"></script>
-  <script src="ai.js"></script>
+  <script src="chatbot.js"></script>
 </head>
 <body>
   <aside class="sidebar">


### PR DESCRIPTION
## Summary
- simplify `chatbot.js` to send chat history to backend only
- update chat UI to call backend and show response with typewriter effect
- remove local AI scripts from `index.html`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687ecc1fbe34832a8bebb1eefb390ff6